### PR TITLE
teste

### DIFF
--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -161,8 +161,7 @@ properties:
         name: 'kmsKeySelfLink'
         api_name: 'kmsKeyName'
         description: |
-          The self link of the encryption key that is stored in Google Cloud
-          KMS.
+          UPDATED: THIS ONE WORKS!
         custom_flatten: 'templates/terraform/custom_flatten/image_kms_key_name.go.erb'
         diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
       - !ruby/object:Api::Type::String

--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -622,10 +622,7 @@ properties:
       - !ruby/object:Api::Type::Enum
         name: 'confidentialInstanceType'
         description: |
-          The confidential computing technology the instance uses.
-          SEV is an AMD feature. TDX is an Intel feature. One of the following
-          values is required: SEV, SEV_SNP, TDX. If SEV_SNP, min_cpu_platform =
-          "AMD Milan" is currently required. TDX is only available in beta.
+          UPDATED: this one doesn't work.
         values:
           - :SEV
           - :SEV_SNP


### PR DESCRIPTION
CLI commands:
```bash
make provider VERSION=ga OUTPUT_PATH="/Users/alisboa/Documents/Google/SBP/terraform-provider-google" PRODUCT=compute
```
and
```bash
make provider VERSION=beta OUTPUT_PATH="/Users/alisboa/Documents/Google/SBP/terraform-provider-google" PRODUCT=compute
```
tried both, without success (only the description of the Image.yaml appears to be being propagated to the other repository)